### PR TITLE
fix(ospo): rename national-digital-twin to national-node-net

### DIFF
--- a/.github/workflows/auto-back-merge.yml
+++ b/.github/workflows/auto-back-merge.yml
@@ -31,8 +31,8 @@ jobs:
         id: sync-token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
-          app-id: ${{ secrets.NDTP_REPOSITORY_WRITER_APP_CLIENT_ID }}
-          private-key: ${{ secrets.NDTP_REPOSITORY_WRITER_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.NODE_NET_REPOSITORY_WRITER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.NODE_NET_REPOSITORY_WRITER_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-workflows: write
 

--- a/.github/workflows/auto-back-merge.yml
+++ b/.github/workflows/auto-back-merge.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Generate Sync Token
         id: sync-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.NODE_NET_REPOSITORY_WRITER_APP_CLIENT_ID }}
           private-key: ${{ secrets.NODE_NET_REPOSITORY_WRITER_APP_PRIVATE_KEY }}
@@ -37,7 +37,7 @@ jobs:
           permission-workflows: write
 
       - name: Merge main into develop and Generate Summary
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.sync-token.outputs.token }}
           script: |

--- a/.github/workflows/federator-suite.ci.yaml
+++ b/.github/workflows/federator-suite.ci.yaml
@@ -23,7 +23,7 @@ on:
 env:
   CHART_DIR: ./charts/
   PACKAGE_NAME: federator-suite
-  REGISTRY: ${{ github.ref == 'refs/heads/main' && 'ghcr.io/national-digital-twin/helm' || 'ghcr.io/national-digital-twin/helm-test' }}
+  REGISTRY: ${{ github.ref == 'refs/heads/main' && 'ghcr.io/national-node-net/helm' || 'ghcr.io/national-node-net/helm-test' }}
   VALUES_FILES: >-
     -f values/common-values.yaml
     -f values/kafka.yaml

--- a/.github/workflows/ia-node-kafka.ci.yaml
+++ b/.github/workflows/ia-node-kafka.ci.yaml
@@ -23,7 +23,7 @@ on:
 env:
   CHART_DIR: ./charts/
   PACKAGE_NAME: ia-node-kafka
-  REGISTRY: ${{ github.ref == 'refs/heads/main' && 'ghcr.io/national-digital-twin/helm' || 'ghcr.io/national-digital-twin/helm-test' }}
+  REGISTRY: ${{ github.ref == 'refs/heads/main' && 'ghcr.io/national-node-net/helm' || 'ghcr.io/national-node-net/helm-test' }}
 
 jobs:
   check:

--- a/.github/workflows/ia-node-mongodb.ci.yaml
+++ b/.github/workflows/ia-node-mongodb.ci.yaml
@@ -23,7 +23,7 @@ on:
 env:
   CHART_DIR: ./charts/
   PACKAGE_NAME: ia-node-mongodb
-  REGISTRY: ${{ github.ref == 'refs/heads/main' && 'ghcr.io/national-digital-twin/helm' || 'ghcr.io/national-digital-twin/helm-test' }}
+  REGISTRY: ${{ github.ref == 'refs/heads/main' && 'ghcr.io/national-node-net/helm' || 'ghcr.io/national-node-net/helm-test' }}
 
 jobs:
   check:

--- a/.github/workflows/ia-node-oidc.ci.yaml
+++ b/.github/workflows/ia-node-oidc.ci.yaml
@@ -23,7 +23,7 @@ on:
 env:
   CHART_DIR: ./charts/
   PACKAGE_NAME: ia-node-oidc
-  REGISTRY: ${{ github.ref == 'refs/heads/main' && 'ghcr.io/national-digital-twin/helm' || 'ghcr.io/national-digital-twin/helm-test' }}
+  REGISTRY: ${{ github.ref == 'refs/heads/main' && 'ghcr.io/national-node-net/helm' || 'ghcr.io/national-node-net/helm-test' }}
 
 jobs:
   check:

--- a/.github/workflows/ia-node.ci.yaml
+++ b/.github/workflows/ia-node.ci.yaml
@@ -23,7 +23,7 @@ on:
 env:
   CHART_DIR: ./charts/
   PACKAGE_NAME: ia-node
-  REGISTRY: ${{ github.ref == 'refs/heads/main' && 'ghcr.io/national-digital-twin/helm' || 'ghcr.io/national-digital-twin/helm-test' }}
+  REGISTRY: ${{ github.ref == 'refs/heads/main' && 'ghcr.io/national-node-net/helm' || 'ghcr.io/national-node-net/helm-test' }}
 
 jobs:
   check:

--- a/.github/workflows/oss-checker.yml
+++ b/.github/workflows/oss-checker.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           app-id: ${{ secrets.OSPO_WORKFLOW_APP_ID }}
           private-key: ${{ secrets.OSPO_WORKFLOW_PRIVATE_KEY }}
-          owner: National-Digital-Twin
+          owner: National-Node-Net
           repositories: ospo-resources
           permission-contents: read
 
@@ -53,14 +53,14 @@ jobs:
       - name: Checkout OSPO source repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: National-Digital-Twin/ospo-resources
+          repository: National-Node-Net/ospo-resources
           path: ospo-resources
           token: ${{ steps.ospo_token.outputs.token }}
 
       - name: Checkout archetypes source repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: National-Digital-Twin/archetypes
+          repository: National-Node-Net/archetypes
           path: archetypes
 
       - name: Fetch Repository Metadata

--- a/.github/workflows/oss-checker.yml
+++ b/.github/workflows/oss-checker.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Fetch GitHub App token for target repo
         id: target_token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.OSPO_WORKFLOW_APP_ID }}
           private-key: ${{ secrets.OSPO_WORKFLOW_PRIVATE_KEY }}
@@ -37,7 +37,7 @@ jobs:
 
       - name: Fetch GitHub App token for OSPO source repo (read-only)
         id: ospo_token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.OSPO_WORKFLOW_APP_ID }}
           private-key: ${{ secrets.OSPO_WORKFLOW_PRIVATE_KEY }}
@@ -46,25 +46,25 @@ jobs:
           permission-contents: read
 
       - name: Checkout target repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ steps.target_token.outputs.token }}
 
       - name: Checkout OSPO source repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: National-Node-Net/ospo-resources
           path: ospo-resources
           token: ${{ steps.ospo_token.outputs.token }}
 
       - name: Checkout archetypes source repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: National-Node-Net/archetypes
           path: archetypes
 
       - name: Fetch Repository Metadata
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         with:
@@ -135,7 +135,7 @@ jobs:
             --output json > policy-report.json || true
 
       - name: Process Policy Results
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
              const { existsSync, readFileSync, writeFileSync } = require('fs');
@@ -202,7 +202,7 @@ jobs:
              }
 
       - name: Test for presence of OSS files and variation from templated content
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         if: success() || failure()
         with:
           script: |
@@ -301,7 +301,7 @@ jobs:
             }
 
       - name: Check GitHub template files are present
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         if: success() || failure()
         with:
           script: |
@@ -372,7 +372,7 @@ jobs:
       - name: Generate summary
         id: summarise_results
         if: always()
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { existsSync, readFileSync } = require('fs');
@@ -466,7 +466,7 @@ jobs:
 
       - name: Upload OSS result artifacts
         if: ${{ steps.summarise_results.outputs.hasResults == 'true' }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: oss-checks-${{ github.run_id }}
           retention-days: 30
@@ -489,7 +489,7 @@ jobs:
 
     steps:
       - name: Comment with OSS summary
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SUMMARY_TABLE: ${{ needs.oss-checks.outputs.summary-table }}
           JOB_RESULT: ${{ needs.oss-checks.result }}

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -73,7 +73,7 @@ jobs:
     needs: [versioning]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Generate SPDX SBOM
         env:
@@ -91,7 +91,7 @@ jobs:
           echo "$api_response" | jq '.sbom' > sbom.spdx.json
 
       - name: Upload SBOM Artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: sbom.spdx.json
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -135,7 +135,7 @@ jobs:
           name: sbom
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: "v${{ needs.versioning.outputs.version }}"
           name: "Release v${{ needs.versioning.outputs.version }}"

--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -19,7 +19,7 @@ We are grateful for the collaboration that has helped shape this repository.
 ## Individual contributions
 
 For a list of individual contributors who have made direct commits to this repository, see
-GitHub’s auto-generated contributor insights: [Contributors](https://github.com/National-Digital-Twin/helm-charts/graphs/contributors).
+GitHub’s auto-generated contributor insights: [Contributors](https://github.com/National-Node-Net/helm-charts/graphs/contributors).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 
 ---
 
-## [Unreleased] 
+## [0.90.2] – 2026-07-16
 
 ### Added 
 - Placeholder for upcoming features and enhancements. 
@@ -26,6 +26,7 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 - Placeholder for bug fixes and security updates. 
 
 ### Changed 
+- Alignment of GitHub actions to new organisation.
 - Placeholder for changes to existing functionality. 
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,8 @@ This project follows **Semantic Versioning (SemVer)** ([semver.org](https://semv
 
 ## [0.90.2] – 2026-07-16
 
-### Added 
-- Placeholder for upcoming features and enhancements. 
-
-### Fixed 
-- Placeholder for bug fixes and security updates. 
-
 ### Changed 
 - Alignment of GitHub actions to new organisation.
-- Placeholder for changes to existing functionality. 
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The National Digital Twin Programme (NDTP) develops and maintains this repositor
 
 NDTP follows an **open-source governance model** where all code is **publicly available** under open-source licences, and collaboration is invited from **approved partners**. Contributions from the general public are not currently accepted, but **feedback, issue reporting, and documentation suggestions are encouraged**.  
 
-If you want to see which suppliers and organisations have contributed to this repository in the past, refer to [ACKNOWLEDGEMENTS.md](./ACKNOWLEDGEMENTS.md) and the GitHub contributor insights page at [Contributors](https://github.com/National-Digital-Twin/helm-charts/graphs/contributors).  
+If you want to see which suppliers and organisations have contributed to this repository in the past, refer to [ACKNOWLEDGEMENTS.md](./ACKNOWLEDGEMENTS.md) and the GitHub contributor insights page at [Contributors](https://github.com/National-Node-Net/helm-charts/graphs/contributors).  
 
 ---
 
@@ -34,7 +34,7 @@ For details on repository maintainers and how to contact them, refer to [MAINTAI
 
 If you encounter a bug, error, or inconsistency, please follow these steps:  
 
-1. Check for an existing issue under [Issues](https://github.com/National-Digital-Twin/helm-charts/issues).  
+1. Check for an existing issue under [Issues](https://github.com/National-Node-Net/helm-charts/issues).  
 2. Open a new issue if no one has reported it yet. Use one of the provided issue templates.  
 3. Provide a clear, detailed description of the issue, including steps to reproduce it if applicable.  
 4. Label the issue appropriately (bug, documentation, enhancement, etc.).  
@@ -61,7 +61,7 @@ We prioritise documentation updates based on user impact and alignment with prog
 - **Development is led by approved suppliers and partners** who have been engaged through a formal process.  
 - **We welcome feedback and ideas**, but implementation is subject to programme priorities.  
 
-To see what we’re working on, check out our [Project Roadmap](https://github.com/National-Digital-Twin/helm-charts/projects). If no roadmap is currently available, please note that it is being actively developed and will be published in due course.  
+To see what we’re working on, check out our [Project Roadmap](https://github.com/National-Node-Net/helm-charts/projects). If no roadmap is currently available, please note that it is being actively developed and will be published in due course.  
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is aimed at being an easy set up for local/dev and should NOT be used `as i
 > Secrets management is outside of the scope of the deployment, however we have provided a few possible examples on how you might override the default values, or provide your own where supported.
 
 >```sh
->git clone https://github.com/National-Digital-Twin/helm-charts.git
+>git clone https://github.com/National-Node-Net/helm-charts.git
 >cd helm-charts
 >```
 
@@ -160,7 +160,7 @@ kubectl -n keycloak create secret generic keycloak-management-node-client --from
 Deploy the [ia-node-oidc](./charts/ia-node-oidc/README.md) helper chart to help with setting up an OIDC conformant Identity Provider (IdP) to work with the IA Node setup.
 
 ```sh
-helm install ia-node-oidc oci://ghcr.io/national-digital-twin/helm/ia-node-oidc -n org-a --set oidcProvider.configMap.redirect_url="http://localhost/oauth2/callback" --set istio.authorizationPolicy.enabled=false
+helm install ia-node-oidc oci://ghcr.io/national-node-net/helm/ia-node-oidc -n org-a --set oidcProvider.configMap.redirect_url="http://localhost/oauth2/callback" --set istio.authorizationPolicy.enabled=false
 ```
 >[!NOTE]
 > if this fails with errors, like 
@@ -201,7 +201,7 @@ Deploy the [ia-node-mongodb](./charts/ia-node-mongodb/README.md) helper chart to
 
 Note: The below --set commands are optional and configured for small environments
 ```sh
-helm install ia-node-mongodb oci://ghcr.io/national-digital-twin/helm/ia-node-mongodb -n org-a \
+helm install ia-node-mongodb oci://ghcr.io/national-node-net/helm/ia-node-mongodb -n org-a \
   --set mongodb.spec.members=1 
 ```
 
@@ -255,7 +255,7 @@ Deploy the [ia-node-kafka](./charts/ia-node-kafka/README.md) helper chart for us
 Note: The chart defaults to Kafka 4.1.0 with KRaft mode (no ZooKeeper) and single broker/controller for small environments. Use the local chart path if you have made local modifications:
 ```sh
 # For published chart:
-helm install ia-node-kafka oci://ghcr.io/national-digital-twin/helm/ia-node-kafka -n org-a 
+helm install ia-node-kafka oci://ghcr.io/national-node-net/helm/ia-node-kafka -n org-a 
 ```
 ```sh
 # For local chart with Kafka 4.1.0 support:
@@ -490,7 +490,7 @@ helm upgrade --install management-node ./charts/management-node \
   --set app.datasource.secret.password=${POSTGRESS_PASSWORD} \
   --set app.datasource.secret.create=true \
   --set app.datasource.url=jdbc:postgresql://management-postgres-postgresql.central-org.svc.cluster.local:5432/management_node \
-  --set image.repository=ghcr.io/national-digital-twin/management-node/management-node \
+  --set image.repository=ghcr.io/national-node-net/management-node/management-node \
   --set image.tag=1.0.1 \
   --set app.ssl.enabled=false \
   --set app.oauth2.resourceserver.jwt.issuerUri=http://keycloak.keycloak.svc.cluster.local/realms/management-node \

--- a/charts/federator-suite/Chart.yaml
+++ b/charts/federator-suite/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for Federator application suite (client, server, kafka, 
 type: application
 version: 0.2.0
 appVersion: "0.4.1"
-home: https://github.com/national-digital-twin/helm-charts
+home: https://github.com/national-node-net/helm-charts
 maintainers:
   - name: National Digital Twin Programme
     email: contact@ndtp.gov.uk

--- a/charts/federator/README.md
+++ b/charts/federator/README.md
@@ -13,7 +13,7 @@ The Helm chart `federator` deploys the NDTP Federator application, which can run
 
 The Federator is an open-source component developed as part of the National Digital Twin Programme (NDTP) to support secure data federation and sharing across organisations.
 
-[Overview of Federator](https://github.com/National-Digital-Twin/integration-architecture-documentation)
+[Overview of Federator](https://github.com/National-Node-Net/integration-architecture-documentation)
 
 > [!IMPORTANT]  
 > Secrets management is outside of the scope of the deployment. However, we have provided several options for managing secrets, including the `configRender` feature that allows you to keep sensitive values in existing Kubernetes Secrets while maintaining configuration files in ConfigMaps.
@@ -23,7 +23,7 @@ The Federator is an open-source component developed as part of the National Digi
 ### Server Mode
 
 ```sh
-helm install federator-server oci://ghcr.io/national-digital-twin/helm/federator -n federator \
+helm install federator-server oci://ghcr.io/national-node-net/helm/federator -n federator \
 --set mode=server \
 --create-namespace
 ```
@@ -31,7 +31,7 @@ helm install federator-server oci://ghcr.io/national-digital-twin/helm/federator
 ### Client Mode
 
 ```sh
-helm install federator-client oci://ghcr.io/national-digital-twin/helm/federator -n federator \
+helm install federator-client oci://ghcr.io/national-node-net/helm/federator -n federator \
 --set mode=client \
 --set service.enabled=false \
 --create-namespace
@@ -40,7 +40,7 @@ helm install federator-client oci://ghcr.io/national-digital-twin/helm/federator
 Optionally, use an overrides file:
 
 ```sh
-helm install federator oci://ghcr.io/national-digital-twin/helm/federator -n federator -f ./overrides.yaml 
+helm install federator oci://ghcr.io/national-node-net/helm/federator -n federator -f ./overrides.yaml 
 ```
 
 ## Prerequisites  
@@ -77,7 +77,7 @@ kubectl create namespace federator
 Install the chart in server mode to expose a gRPC service:
 
 ```sh
-helm install federator-server oci://ghcr.io/national-digital-twin/helm/federator -n federator \
+helm install federator-server oci://ghcr.io/national-node-net/helm/federator -n federator \
 --set mode=server
 ```
 
@@ -86,7 +86,7 @@ helm install federator-server oci://ghcr.io/national-digital-twin/helm/federator
 Install the chart in client mode to consume from remote servers:
 
 ```sh
-helm install federator-client oci://ghcr.io/national-digital-twin/helm/federator -n federator \
+helm install federator-client oci://ghcr.io/national-node-net/helm/federator -n federator \
 --set mode=client \
 --set service.enabled=false
 ```
@@ -267,10 +267,10 @@ The chart uses separate image repositories for server and client modes:
 ```yaml
 images:
   server:
-    repository: ghcr.io/national-digital-twin/federator/federator-server
+    repository: ghcr.io/national-node-net/federator/federator-server
     tag: 1.0.0
   client:
-    repository: ghcr.io/national-digital-twin/federator/federator-client
+    repository: ghcr.io/national-node-net/federator/federator-client
     tag: 1.0.0
 
 image:
@@ -420,9 +420,9 @@ args: "--debug --verbose"
 
 | Name                        | Description                     | Value                                                      |
 | --------------------------- | ------------------------------- | ---------------------------------------------------------- |
-| `images.server.repository`  | Server mode image repository    | `ghcr.io/national-digital-twin/federator/federator-server` |
+| `images.server.repository`  | Server mode image repository    | `ghcr.io/national-node-net/federator/federator-server` |
 | `images.server.tag`         | Server mode image tag           | `1.0.0`                                                    |
-| `images.client.repository`  | Client mode image repository    | `ghcr.io/national-digital-twin/federator/federator-client` |
+| `images.client.repository`  | Client mode image repository    | `ghcr.io/national-node-net/federator/federator-client` |
 | `images.client.tag`         | Client mode image tag           | `1.0.0`                                                    |
 | `image.repository`          | Override image repository       | `""`                                                       |
 | `image.tag`                 | Override image tag              | `""`                                                       |

--- a/charts/federator/examples/values-client-example.yaml
+++ b/charts/federator/examples/values-client-example.yaml
@@ -18,7 +18,7 @@ mode: client
 
 images:
   client:
-    repository: ghcr.io/national-digital-twin/federator/federator-client
+    repository: ghcr.io/national-node-net/federator/federator-client
     tag: "1.0.0"
 
 image:

--- a/charts/federator/examples/values-server-example.yaml
+++ b/charts/federator/examples/values-server-example.yaml
@@ -16,7 +16,7 @@ mode: server
 
 images:
   server:
-    repository: ghcr.io/national-digital-twin/federator/federator-server
+    repository: ghcr.io/national-node-net/federator/federator-server
     tag: "1.0.0"
 
 image:

--- a/charts/federator/values.yaml
+++ b/charts/federator/values.yaml
@@ -7,10 +7,10 @@ mode: server
 
 images:
   server:
-    repository: ghcr.io/national-digital-twin/federator/federator-server
+    repository: ghcr.io/national-node-net/federator/federator-server
     tag: 1.0.0
   client:
-    repository: ghcr.io/national-digital-twin/federator/federator-client
+    repository: ghcr.io/national-node-net/federator/federator-client
     tag: 1.0.0
 
 image:

--- a/charts/ia-node-kafka/README.md
+++ b/charts/ia-node-kafka/README.md
@@ -24,13 +24,13 @@ This chart has been developed to provide an example deployment of a Kafka Cluste
 > The installation assumes that Istio has already been installed Istio, following the [Istio Helm Install](https://istio.io/latest/docs/setup/install/helm/) guide, and assumes a default principal of `cluster.local/ns/istio-system/sa/ingressgateway`, and default gateway of `istio-system/istio-gateway`.
 
 ```sh
-helm install my-release oci://ghcr.io/national-digital-twin/helm/ia-node-kafka -n ia-node
+helm install my-release oci://ghcr.io/national-node-net/helm/ia-node-kafka -n ia-node
 ```
 
 Optionally, use an overrides.yaml:
 
 ```sh
-helm install my-release oci://ghcr.io/national-digital-twin/helm/ia-node-kafka -n ia-node -f ./overrides.yaml 
+helm install my-release oci://ghcr.io/national-node-net/helm/ia-node-kafka -n ia-node -f ./overrides.yaml 
 ```
 
 ## Prerequisites
@@ -83,13 +83,13 @@ kubectl label namespace ia-node istio-injection=enabled
 Install the latest chart (defaults to Kafka 4.1.0 with KRaft mode for small environments): 
 
 ```sh
-helm install ia-node-kafka oci://ghcr.io/national-digital-twin/helm/ia-node-kafka -n ia-node
+helm install ia-node-kafka oci://ghcr.io/national-node-net/helm/ia-node-kafka -n ia-node
 ```
 
 Optionally, use an overrides.yaml:
 
 ```sh
-helm install ia-node-kafka oci://ghcr.io/national-digital-twin/helm/ia-node-kafka -n ia-node -f ./overrides.yaml 
+helm install ia-node-kafka oci://ghcr.io/national-node-net/helm/ia-node-kafka -n ia-node -f ./overrides.yaml 
 ```
 
 > [!NOTE]
@@ -129,7 +129,7 @@ This chart provides a few options for managing the default secrets.
 Override the secret value you pass to the chart on a Helm install/upgrade.
 
 ```sh
-helm upgrade ia-node-kafka oci://ghcr.io/national-digital-twin/helm/ia-node-kafka -n ia-node \
+helm upgrade ia-node-kafka oci://ghcr.io/national-node-net/helm/ia-node-kafka -n ia-node \
   --set kafkaCluster.secret.password=ADD_YOUR_PASSWORD_HERE 
 ```
 
@@ -187,7 +187,7 @@ kubectl apply -f ./kafkaclustersecret.yaml -n ia-node
 Lastly, override the values on the install/upgrade replacing the secret name and username to match those you created: 
 
 ```sh 
-helm upgrade ia-node-kafkaCluster oci://ghcr.io/national-digital-twin/helm/ia-node-kafkaCluster -n ia-node \
+helm upgrade ia-node-kafkaCluster oci://ghcr.io/national-node-net/helm/ia-node-kafkaCluster -n ia-node \
 --set kafkaCluster.secret.create=false \
 --set kafkaCluster.secret.name=kafka-auth-config \
 --set kafkaCluster.secret.username=user

--- a/charts/ia-node-mongodb/README.md
+++ b/charts/ia-node-mongodb/README.md
@@ -24,13 +24,13 @@ This chart has been developed to provide a simple example for deploying a MongoD
 > The installation assumes that Istio has already been installed Istio, following the [Istio Helm Install](https://istio.io/latest/docs/setup/install/helm/) guide, and assumes a default principal of `cluster.local/ns/istio-system/sa/ingressgateway`, and default gateway of `istio-system/istio-gateway`. 
 
 ```sh
-helm install my-release oci://ghcr.io/national-digital-twin/helm/ia-node-mongodb -n ia-node
+helm install my-release oci://ghcr.io/national-node-net/helm/ia-node-mongodb -n ia-node
 ```
 
 Optionally, use an overrides.yaml:
 
 ```sh
-helm install my-release oci://ghcr.io/national-digital-twin/helm/ia-node-mongodb -n ia-node -f ./overrides.yaml 
+helm install my-release oci://ghcr.io/national-node-net/helm/ia-node-mongodb -n ia-node -f ./overrides.yaml 
 ```
 
 ## Prerequisites  
@@ -83,13 +83,13 @@ kubectl label namespace ia-node istio-injection=enabled
 Install the latest chart:  
 
 ```sh
-helm install ia-node-mongodb oci://ghcr.io/national-digital-twin/helm/ia-node-mongodb -n ia-node
+helm install ia-node-mongodb oci://ghcr.io/national-node-net/helm/ia-node-mongodb -n ia-node
 ```
 
 Optionally, use an overrides.yaml:
 
 ```sh
-helm install ia-node-mongodb oci://ghcr.io/national-digital-twin/helm/ia-node-mongodb -n ia-node -f ./overrides.yaml 
+helm install ia-node-mongodb oci://ghcr.io/national-node-net/helm/ia-node-mongodb -n ia-node -f ./overrides.yaml 
 ```
 
 To quickly view the database running, setup a port forward.
@@ -134,7 +134,7 @@ This chart provides a few options for managing the default secrets.
 Override the secret value you pass to the chart on a Helm install/upgrade.
 
 ```sh
-helm upgrade ia-node-mongodb oci://ghcr.io/national-digital-twin/helm/ia-node-mongodb -n ia-node \
+helm upgrade ia-node-mongodb oci://ghcr.io/national-node-net/helm/ia-node-mongodb -n ia-node \
   --set mongodb.secret.password=ADD_YOUR_PASSWORD_HERE 
 ```
 
@@ -169,7 +169,7 @@ kubectl apply -f ./mongdbsecret.yaml -n ia-node
 Lastly, override the values on the install/upgrade: 
 
 ```sh 
-helm upgrade ia-node-mongodb oci://ghcr.io/national-digital-twin/helm/ia-node-mongodb -n ia-node \
+helm upgrade ia-node-mongodb oci://ghcr.io/national-node-net/helm/ia-node-mongodb -n ia-node \
 --set mongodb.secret.create=false \
 --set mongodb.secret.name=user-password
 ```

--- a/charts/ia-node-oidc/README.md
+++ b/charts/ia-node-oidc/README.md
@@ -33,13 +33,13 @@ This chart has been developed to provide an example for deploying oAuth2 Proxy, 
 > You can either generate a secret called `oauth2-proxy-default` yourself, or secret creation to true as below with your [cookie secret](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/) and keycloak client id and secret which will generate a secret for you. The config map and optional secret output from the package, can then be used to override the oauth2 Proxy installation. 
 
 ```sh
-helm install ia-node-oidc oci://ghcr.io/national-digital-twin/helm/ia-node-oidc -n ia-node --set oidcProvider.configMap.redirect_url=https://localhost/oauth2/callback --set istio.virtualService.hosts[0]="localhost"
+helm install ia-node-oidc oci://ghcr.io/national-node-net/helm/ia-node-oidc -n ia-node --set oidcProvider.configMap.redirect_url=https://localhost/oauth2/callback --set istio.virtualService.hosts[0]="localhost"
 ```
 
 Optionally, use an overrides.yaml:
 
 ```sh
-helm install my-release oci://ghcr.io/national-digital-twin/helm/ia-node-oidc -n ia-node -f ./overrides.yaml 
+helm install my-release oci://ghcr.io/national-node-net/helm/ia-node-oidc -n ia-node -f ./overrides.yaml 
 ```
 
 ## Prerequisites
@@ -65,7 +65,7 @@ Versions highlighted are based on what configurations have been used throughout 
   - [`oAuth2Proxy`](https://oauth2-proxy.github.io/oauth2-proxy/): a reverse proxy that should be deployed and integrated with Istio service mesh to provide authentication using a target OpenID Connect (OIDC) Identity Provider, this install used [`Bitnami oAuth2 Proxy Helm chart 6.2.10`](https://github.com/bitnami/charts/blob/main/bitnami/oauth2-proxy/README.md), which also installs [`Redis`](https://redis.io/) a session storage option that can be used with oAuth2Proxy
 
 > [!NOTE]
-> The application itself has also been tested with Cognito in place of Keycloak [see here](https://github.com/National-Digital-Twin/integration-architecture-documentation/blob/main/DeveloperDocumentation/Deployment/deployment-local.md). 
+> The application itself has also been tested with Cognito in place of Keycloak [see here](https://github.com/National-Node-Net/integration-architecture-documentation/blob/main/DeveloperDocumentation/Deployment/deployment-local.md). 
   
 ## Installing the Chart
 
@@ -86,13 +86,13 @@ kubectl label namespace ia-node istio-injection=enabled
 Install the latest chart using the following.  
 
 ```sh
-helm install ia-node-oidc oci://ghcr.io/national-digital-twin/helm/ia-node-oidc -n ia-node --set oidcProvider.configMap.redirect_url=https://localhost/oauth2/callback
+helm install ia-node-oidc oci://ghcr.io/national-node-net/helm/ia-node-oidc -n ia-node --set oidcProvider.configMap.redirect_url=https://localhost/oauth2/callback
 ```
 
 Optionally, use an overrides.yaml:
 
 ```sh
-helm install ia-node-oidc oci://ghcr.io/national-digital-twin/helm/ia-node-oidc -n ia-node-oidc -f ./overrides.yaml 
+helm install ia-node-oidc oci://ghcr.io/national-node-net/helm/ia-node-oidc -n ia-node-oidc -f ./overrides.yaml 
 ```
 
 Next install oAuth2Proxy, the example below uses the [Bitnami oAuth2 Proxy Helm chart](https://github.com/bitnami/charts/blob/main/bitnami/oauth2-proxy/README.md), however [oAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/installation) do provide a Helm chart option directly from the core documentation. 
@@ -203,7 +203,7 @@ The payload content should contain email and groups, as shown in the example bel
 }
 ```
 
-There are some examples of Cognito covered in the [documents repository](https://github.com/National-Digital-Twin/integration-architecture-documentation/blob/main/DeveloperDocumentation/Deployment/deployment-local.md).
+There are some examples of Cognito covered in the [documents repository](https://github.com/National-Node-Net/integration-architecture-documentation/blob/main/DeveloperDocumentation/Deployment/deployment-local.md).
 
 The rest of this section is to provide a bit of a quick guide example for a basic Key Cloak configuration. 
 

--- a/charts/ia-node/README.md
+++ b/charts/ia-node/README.md
@@ -11,7 +11,7 @@ The Helm chart `ia-node` is intended to deploy the basic IA Node application com
 
 IA Node (Integration Architecture Node), is an open-source digital component developed as part of the National Digital Twin Programme (NDTP) to support managing and sharing information across organisations, the package `ia-node` intends to ease first time deployments for testing. 
 
-[Overview of IA Node](https://github.com/National-Digital-Twin/integration-architecture-documentation)
+[Overview of IA Node](https://github.com/National-Node-Net/integration-architecture-documentation)
 
 > [!IMPORTANT]  
 > Secrets management is outside of the scope of the deployment, however, we have provided a few possible examples on how you might override the default values or provide your own where supported.
@@ -22,7 +22,7 @@ IA Node (Integration Architecture Node), is an open-source digital component dev
 > The installation assumes that Istio has already been installed Istio, following the [Istio Helm Install](https://istio.io/latest/docs/setup/install/helm/) guide, and assumes a default principal of `cluster.local/ns/istio-system/sa/ingressgateway`, and default gateway of `istio-system/istio-gateway`. It is also assumed that you have Istio installed and you have configured an Istio gateway using the default setup and then in addition configured a mesh config or envoy filter to handle the redirection of OAuth2 Proxy, configured with an OIDC provider. In addition you should also have a MongoDB and Kafka installation which is assumed for the default install i.e. `mongodb-svc:27017` and `kafka-cluster-kafka-bootstrap.ia-node-kafka.svc:9093` respectively using secret names of `ia-node-user-password` and `kafka-auth-config` respectively. These can all be overridden in the values as required, along with any other requirements if you are hosting these services externally. 
 
 ```sh
-helm install my-release oci://ghcr.io/national-digital-twin/helm/ia-node -n ia-node \
+helm install my-release oci://ghcr.io/national-node-net/helm/ia-node -n ia-node \
 --set apps.api.configMap.data.DEPLOYED_DOMAIN="http://localhost" \
 --set apps.api.configMap.data.OPENID_PROVIDER_URL="http://keycloak.keycloak.svc.cluster.local/realms/ianode/" \
 --set apps.graph.configMap.data.JWKS_URL="http://keycloak.keycloak.svc.cluster.local/realms/ianode/.well-known/openid-configuration" \
@@ -32,7 +32,7 @@ helm install my-release oci://ghcr.io/national-digital-twin/helm/ia-node -n ia-n
 Optionally, use an overrides.yaml:
 
 ```sh
-helm install my-release oci://ghcr.io/national-digital-twin/helm/ia-node -n ia-node -f ./overrides.yaml 
+helm install my-release oci://ghcr.io/national-node-net/helm/ia-node -n ia-node -f ./overrides.yaml 
 ```
 
 ## Prerequisites  
@@ -77,7 +77,7 @@ kubectl label namespace ia-node istio-injection=enabled
 Install the latest chart using the following:  
 
 ```sh
-helm install ia-node oci://ghcr.io/national-digital-twin/helm/ia-node -n ia-node \
+helm install ia-node oci://ghcr.io/national-node-net/helm/ia-node -n ia-node \
 --set apps.api.configMap.data.DEPLOYED_DOMAIN="http://localhost" \
 --set apps.api.configMap.data.OPENID_PROVIDER_URL="http://keycloak.keycloak.svc.cluster.local/realms/ianode/" \
 --set apps.graph.configMap.data.JWKS_URL="http://keycloak.keycloak.svc.cluster.local/realms/ianode/.well-known/openid-configuration" \
@@ -87,7 +87,7 @@ helm install ia-node oci://ghcr.io/national-digital-twin/helm/ia-node -n ia-node
 Optionally, use an overrides.yaml:
 
 ```sh
-helm install ia-node oci://ghcr.io/national-digital-twin/helm/ia-node -n ia-node -f ./overrides.yaml 
+helm install ia-node oci://ghcr.io/national-node-net/helm/ia-node -n ia-node -f ./overrides.yaml 
 ```
 
 ## Uninstall the Chart
@@ -198,7 +198,7 @@ This chart provides a few options for managing the default secrets.
 Override the secret value you pass to the chart with a Helm install/upgrade. 
 
 ```sh
-helm upgrade ia-node oci://ghcr.io/national-digital-twin/helm/ia-node -n ia-node --set mongodb.secret.password=ADD_YOUR_PASSWORD_HERE 
+helm upgrade ia-node oci://ghcr.io/national-node-net/helm/ia-node -n ia-node --set mongodb.secret.password=ADD_YOUR_PASSWORD_HERE 
 ```
 
 Verify the default is now configured by running: 
@@ -234,7 +234,7 @@ kubectl apply -f ./mongdbsecret.yaml -n ia-node
 Lastly override the values on the install/upgrade as below. 
 
 ```sh
-helm upgrade ia-node oci://ghcr.io/national-digital-twin/helm/ia-node -n ia-node \
+helm upgrade ia-node oci://ghcr.io/national-node-net/helm/ia-node -n ia-node \
 --set mongodb.secret.create=false \
 --set mongodb.secret.name=bring-your-own-mongdb-secret-reference
 ```
@@ -275,7 +275,7 @@ extraCerts:
 
 #### Referencing Alternative or Private Registries for Images
 
-All images are all published to a the National Digital Twin Programme GitHub Registry see [here](https://github.com/orgs/National-Digital-Twin/packages?ecosystem=container). 
+All images are all published to a the National Digital Twin Programme GitHub Registry see [here](https://github.com/orgs/National-Node-Net/packages?ecosystem=container). 
 
 Some teams, may wish to sync images to another registry they host or sync to a registry that is already integrated with their desired target environment cluster, however others may wish to use the private github registry directly.
 
@@ -289,7 +289,7 @@ You will require an access token with at least "read only" access either
 Then log in to the target registry as follows. 
 
 ```sh
- docker login -u user ghcr.io/national-digital-twin -p $token
+ docker login -u user ghcr.io/national-node-net -p $token
 ```
 
 This should generate a config i.e. .docker/config.json you can view the contents using 
@@ -311,7 +311,7 @@ If you can't find a config you can also do this directly
 
 ```sh
 kubectl create secret docker-registry private-registry \
---docker-server=ghcr.io/national-digital-twin \
+--docker-server=ghcr.io/national-node-net \
 --docker-username=user \
 --docker-password=$token \
 --docker-email=user@yourdomain \
@@ -402,7 +402,7 @@ imagePullSecrets:
 | Name                                 | Description                                              | Value                                       |
 | ------------------------------------ | -------------------------------------------------------- | ------------------------------------------- |
 | apps.api.enabled                     | toggled the component to be deployed or not              | true                                        |
-| apps.api.deployment.image.repository | default image repository                                 | ghcr.io/national-digital-twin/ianode-access |
+| apps.api.deployment.image.repository | default image repository                                 | ghcr.io/national-node-net/ianode-access |
 | apps.api.deployment.image.tag        | default image tag                                        | 0.90.0                                      |
 | apps.api.configMap.data              | config map overrides, only the ones listed are mandatory | DEPLOYED_DOMAIN, OPENID_PROVIDER_URL        |
 
@@ -413,7 +413,7 @@ Note: currently access-ui image is not supported yet.
 | Name                                | Description                                              | Value                                   |
 | ----------------------------------- | -------------------------------------------------------- | --------------------------------------- |
 | apps.ui.enabled                     | toggled the component to be deployed or not              | false                                   |
-| apps.ui.deployment.image.repository | default image repository                                 | ghcr.io/national-digital-twin/access-ui |
+| apps.ui.deployment.image.repository | default image repository                                 | ghcr.io/national-node-net/access-ui |
 | apps.ui.deployment.image.tag        | default image tag                                        | latest                                  |
 | apps.ui.configMap.data              | config map overrides, only the ones listed are mandatory | env-config.js                           |
 
@@ -422,7 +422,7 @@ Note: currently access-ui image is not supported yet.
 | Name                                  | Description                                              | Value                                                                  |
 | ------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------- |
 | apps.api.graph                        | toggled the component to be deployed or not              | true                                                                   |
-| apps.api.statefulSet.image.repository | default image repository                                 | ghcr.io/national-digital-twin/secure-agent-graph                       |
+| apps.api.statefulSet.image.repository | default image repository                                 | ghcr.io/national-node-net/secure-agent-graph                       |
 | apps.api.statefulSet.image.tag        | default image tag                                        | 0.90.0                                                                 |
 | apps.api.configMap.data               | config map overrides, only the ones listed are mandatory | ATTRIBUTE_HIERARCHY_URL, JWKS_URL, SEARCH_API_URL, USER_ATTRIBUTES_URL |
 
@@ -433,7 +433,7 @@ Note: currently query-ui image is not supported yet.
 | Name                                   | Description                                              | Value                                  |
 | -------------------------------------- | -------------------------------------------------------- | -------------------------------------- |
 | apps.graph.enabled                     | toggled the component to be deployed or not              | false                                  |
-| apps.graph.deployment.image.repository | default image repository                                 | ghcr.io/national-digital-twin/query-ui |
+| apps.graph.deployment.image.repository | default image repository                                 | ghcr.io/national-node-net/query-ui |
 | apps.graph.deployment.image.tag        | default image tag                                        | latest                                 |
 | apps.graph.configMap.data              | config map overrides, only the ones listed are mandatory | env-config.js                          |
 

--- a/charts/ia-node/values.yaml
+++ b/charts/ia-node/values.yaml
@@ -87,7 +87,7 @@ apps:
       replicas: 1
       containerPort: 8080
       image:
-        repository: ghcr.io/national-digital-twin/ianode-access
+        repository: ghcr.io/national-node-net/ianode-access
         tag: 0.90.0
       resources:
         limits:
@@ -131,7 +131,7 @@ apps:
       replicas: 1
       containerPort: 80
       image:
-        repository: ghcr.io/national-digital-twin/access-ui ### currently unsupported and just a placeholder only
+        repository: ghcr.io/national-node-net/access-ui ### currently unsupported and just a placeholder only
         tag: latest
       resources:
         limits:
@@ -185,7 +185,7 @@ apps:
         prometheus.io/scrape: "true"
       replicas: 1
       image:
-        repository: ghcr.io/national-digital-twin/secure-agent-graph
+        repository: ghcr.io/national-node-net/secure-agent-graph
         tag: 0.90.0
       ports:
       - name: http
@@ -290,7 +290,7 @@ apps:
       replicas: 1
       containerPort: 8080
       image:
-        repository: ghcr.io/national-digital-twin/query-ui ### currently unsupported and just a placeholder only
+        repository: ghcr.io/national-node-net/query-ui ### currently unsupported and just a placeholder only
         tag: latest
       resources:
         limits:

--- a/charts/management-node/README.md
+++ b/charts/management-node/README.md
@@ -6,7 +6,7 @@ This chart deploys the management-node service as a Kubernetes Deployment expose
 
 - Kubernetes 1.25+
 - Helm 3.12+
-- Access to pull `ghcr.io/national-digital-twin/management-node` images (authenticate to GHCR if required)
+- Access to pull `ghcr.io/national-node-net/management-node` images (authenticate to GHCR if required)
 
 ## Quick Start
 
@@ -20,7 +20,7 @@ To override the image reference or tag:
 
 ```bash
 helm install management-node ./charts/management-node \
-  --set image.repository=ghcr.io/national-digital-twin/management-node \
+  --set image.repository=ghcr.io/national-node-net/management-node \
   --set image.tag=1.0.1
 ```
 
@@ -41,7 +41,7 @@ helm uninstall management-node
 | Key | Default | Description |
 | --- | --- | --- |
 | `replicaCount` | `1` | Number of pods in the deployment. |
-| `image.repository` | `ghcr.io/national-digital-twin/management-node` | Container image repository. |
+| `image.repository` | `ghcr.io/national-node-net/management-node` | Container image repository. |
 | `image.tag` | `1.0.1` | Container image tag. |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy for the container. |
 | `serviceAccount.create` | `true` | Whether to create a dedicated ServiceAccount. |

--- a/charts/management-node/README.md
+++ b/charts/management-node/README.md
@@ -6,7 +6,7 @@ This chart deploys the management-node service as a Kubernetes Deployment expose
 
 - Kubernetes 1.25+
 - Helm 3.12+
-- Access to pull `ghcr.io/national-node-net/management-node` images (authenticate to GHCR if required)
+- Access to pull `ghcr.io/national-node-net/management-node/management-node` images (authenticate to GHCR if required)
 
 ## Quick Start
 

--- a/charts/management-node/README.md
+++ b/charts/management-node/README.md
@@ -41,7 +41,7 @@ helm uninstall management-node
 | Key | Default | Description |
 | --- | --- | --- |
 | `replicaCount` | `1` | Number of pods in the deployment. |
-| `image.repository` | `ghcr.io/national-node-net/management-node` | Container image repository. |
+| `image.repository` | `ghcr.io/national-node-net/management-node/management-node` | Container image repository. |
 | `image.tag` | `1.0.1` | Container image tag. |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy for the container. |
 | `serviceAccount.create` | `true` | Whether to create a dedicated ServiceAccount. |

--- a/charts/management-node/values.yaml
+++ b/charts/management-node/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/national-digital-twin/management-node/management-node
+  repository: ghcr.io/national-node-net/management-node/management-node
   tag: "1.0.1"
   pullPolicy: IfNotPresent
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -8,8 +8,8 @@ $InstallOperators=$false
 
 switch ($InstallType) {
     "local_dev"     {$Directory="./helm-charts/charts" } ## for developing the and editing the charts
-    "test_package"  {$Directory="oci://ghcr.io/national-digital-twin/helm-test"} ## for deployment with the test packages
-    default         {$Directory="oci://ghcr.io/national-digital-twin/helm"} ## for default deployment using the live public packages
+    "test_package"  {$Directory="oci://ghcr.io/national-node-net/helm-test"} ## for deployment with the test packages
+    default         {$Directory="oci://ghcr.io/national-node-net/helm"} ## for default deployment using the live public packages
  }
 
 kubectl create namespace $Namespace

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,10 +11,10 @@ case $INSTALL_TYPE in
         Directory="./helm-charts/charts"
         ;;
     "test_package")
-        Directory="oci://ghcr.io/national-digital-twin/helm-test"
+        Directory="oci://ghcr.io/national-node-net/helm-test"
         ;;
     *)
-        Directory="oci://ghcr.io/national-digital-twin/helm"
+        Directory="oci://ghcr.io/national-node-net/helm"
         ;;
 esac
 


### PR DESCRIPTION
Alignment of GitHub actions to the new organisation (National-Digital-Twin -> National-Node-Net), plus dependent secret renames and CHANGELOG entry.